### PR TITLE
bugfix/selecting-child-folders

### DIFF
--- a/packages/client/src/components/FilesSelector/FilesSelector.types.ts
+++ b/packages/client/src/components/FilesSelector/FilesSelector.types.ts
@@ -134,6 +134,7 @@ export type FilesSelectorProps = {
   isEditorDialog: boolean;
   setMoveToPublicRoomVisible: (visible: boolean, operationData: object) => void;
   setBackupToPublicRoomVisible: (visible: boolean, data: object) => void;
+  getIcon: (size: number, fileExst: string) => string;
 
   onClose?: () => void;
 

--- a/packages/client/src/components/FilesSelector/FilesSelector.types.ts
+++ b/packages/client/src/components/FilesSelector/FilesSelector.types.ts
@@ -121,7 +121,7 @@ export type useFilesHelpersProps = {
   ) => void;
   getIcon: (size: number, fileExst: string) => string;
   t: any;
-  selectionId?: string | number | null;
+  selectedFolders: any[];
 };
 
 export type FilesSelectorProps = {
@@ -156,7 +156,7 @@ export type FilesSelectorProps = {
 
   selection: any[];
   disabledItems: string[] | number[];
-  selectionId?: string | number | null;
+  selectedFolders: any[];
   setMoveToPanelVisible: (value: boolean) => void;
   setRestorePanelVisible: (value: boolean) => void;
   setCopyPanelVisible: (value: boolean) => void;

--- a/packages/client/src/components/FilesSelector/FilesSelector.types.ts
+++ b/packages/client/src/components/FilesSelector/FilesSelector.types.ts
@@ -92,6 +92,7 @@ export type useRoomsHelperProps = {
 export type useFilesHelpersProps = {
   setBreadCrumbs: (items: BreadCrumb[]) => void;
   setIsBreadCrumbsLoading: (value: boolean) => void;
+  setIsSelectedParentFolder: (value: boolean) => void;
   setIsNextPageLoading: (value: boolean) => void;
   setHasNextPage: (value: boolean) => void;
   setTotal: (value: number) => void;
@@ -120,6 +121,7 @@ export type useFilesHelpersProps = {
   ) => void;
   getIcon: (size: number, fileExst: string) => string;
   t: any;
+  selectionId?: string | number | null;
 };
 
 export type FilesSelectorProps = {
@@ -154,6 +156,7 @@ export type FilesSelectorProps = {
 
   selection: any[];
   disabledItems: string[] | number[];
+  selectionId?: string | number | null;
   setMoveToPanelVisible: (value: boolean) => void;
   setRestorePanelVisible: (value: boolean) => void;
   setCopyPanelVisible: (value: boolean) => void;

--- a/packages/client/src/components/FilesSelector/FilesSelector.types.ts
+++ b/packages/client/src/components/FilesSelector/FilesSelector.types.ts
@@ -121,7 +121,6 @@ export type useFilesHelpersProps = {
   ) => void;
   getIcon: (size: number, fileExst: string) => string;
   t: any;
-  selectedFolders: any[];
 };
 
 export type FilesSelectorProps = {
@@ -157,7 +156,6 @@ export type FilesSelectorProps = {
 
   selection: any[];
   disabledItems: string[] | number[];
-  selectedFolders: any[];
   setMoveToPanelVisible: (value: boolean) => void;
   setRestorePanelVisible: (value: boolean) => void;
   setCopyPanelVisible: (value: boolean) => void;

--- a/packages/client/src/components/FilesSelector/helpers/useFilesHelper.ts
+++ b/packages/client/src/components/FilesSelector/helpers/useFilesHelper.ts
@@ -27,7 +27,8 @@ import toastr from "@docspace/components/toast/toastr";
 export const convertFoldersToItems = (
   folders: any,
   disabledItems: any[],
-  filterParam?: string
+  filterParam?: string,
+  selectionId?: string | number | null
 ) => {
   const items = folders.map((room: any) => {
     const {
@@ -51,6 +52,9 @@ export const convertFoldersToItems = (
     } = room;
 
     const icon = iconSize32.get("folder.svg");
+
+    const isSelectedFolderParent = selectionId && parentId === selectionId;
+    if (!filterParam && isSelectedFolderParent) disabledItems.push(id);
 
     return {
       id,
@@ -129,6 +133,8 @@ export const useFilesHelper = ({
   getRoomList,
   getIcon,
   t,
+  selectionId,
+  setIsSelectedParentFolder,
 }: useFilesHelpersProps) => {
   const getFileList = React.useCallback(
     async (
@@ -227,7 +233,8 @@ export const useFilesHelper = ({
         const foldersList: Item[] = convertFoldersToItems(
           folders,
           disabledItems,
-          filterParam
+          filterParam,
+          selectionId
         );
 
         const filesList: Item[] = convertFilesToItems(
@@ -258,6 +265,10 @@ export const useFilesHelper = ({
 
               // const { title, id, parentId, rootFolderType, roomType } =
               //   folderInfo;
+
+              if (selectionId == id) {
+                setIsSelectedParentFolder(true);
+              }
 
               return {
                 label: title,

--- a/packages/client/src/components/FilesSelector/helpers/useFilesHelper.ts
+++ b/packages/client/src/components/FilesSelector/helpers/useFilesHelper.ts
@@ -27,8 +27,7 @@ import toastr from "@docspace/components/toast/toastr";
 export const convertFoldersToItems = (
   folders: any,
   disabledItems: any[],
-  filterParam?: string,
-  selectionId?: string | number | null
+  filterParam?: string
 ) => {
   const items = folders.map((room: any) => {
     const {
@@ -52,9 +51,6 @@ export const convertFoldersToItems = (
     } = room;
 
     const icon = iconSize32.get("folder.svg");
-
-    const isSelectedFolderParent = selectionId && parentId === selectionId;
-    if (!filterParam && isSelectedFolderParent) disabledItems.push(id);
 
     return {
       id,
@@ -133,7 +129,7 @@ export const useFilesHelper = ({
   getRoomList,
   getIcon,
   t,
-  selectionId,
+  selectedFolders,
   setIsSelectedParentFolder,
 }: useFilesHelpersProps) => {
   const getFileList = React.useCallback(
@@ -233,8 +229,7 @@ export const useFilesHelper = ({
         const foldersList: Item[] = convertFoldersToItems(
           folders,
           disabledItems,
-          filterParam,
-          selectionId
+          filterParam
         );
 
         const filesList: Item[] = convertFilesToItems(
@@ -251,6 +246,9 @@ export const useFilesHelper = ({
           setSelectedTreeNode({ ...current, path: pathParts });
 
         if (isInit) {
+          let foundParentId = false,
+            currentFolderIndex = -1;
+
           const breadCrumbs: BreadCrumb[] = pathParts.map(
             ({
               id,
@@ -266,9 +264,11 @@ export const useFilesHelper = ({
               // const { title, id, parentId, rootFolderType, roomType } =
               //   folderInfo;
 
-              if (selectionId == id) {
-                setIsSelectedParentFolder(true);
+              if (!foundParentId) {
+                currentFolderIndex = selectedFolders.findIndex((x) => x === id);
               }
+
+              if (currentFolderIndex !== -1) setIsSelectedParentFolder(true);
 
               return {
                 label: title,

--- a/packages/client/src/components/FilesSelector/helpers/useFilesHelper.ts
+++ b/packages/client/src/components/FilesSelector/helpers/useFilesHelper.ts
@@ -73,8 +73,8 @@ export const convertFoldersToItems = (
 
 export const convertFilesToItems = (
   files: any,
-  filterParam?: string,
-  getIcon: (size: number, fileExst: string) => string
+  getIcon: (size: number, fileExst: string) => string,
+  filterParam?: string
 ) => {
   const items = files.map((file: any) => {
     const {
@@ -233,8 +233,8 @@ export const useFilesHelper = ({
 
         const filesList: Item[] = convertFilesToItems(
           files,
-          filterParam,
-          getIcon
+          getIcon,
+          filterParam
         );
 
         const itemList = [...foldersList, ...filesList];

--- a/packages/client/src/components/FilesSelector/helpers/useFilesHelper.ts
+++ b/packages/client/src/components/FilesSelector/helpers/useFilesHelper.ts
@@ -268,7 +268,10 @@ export const useFilesHelper = ({
                 currentFolderIndex = selectedFolders.findIndex((x) => x === id);
               }
 
-              if (currentFolderIndex !== -1) setIsSelectedParentFolder(true);
+              if (!foundParentId && currentFolderIndex !== -1) {
+                foundParentId = true;
+                setIsSelectedParentFolder(true);
+              }
 
               return {
                 label: title,

--- a/packages/client/src/components/FilesSelector/helpers/useFilesHelper.ts
+++ b/packages/client/src/components/FilesSelector/helpers/useFilesHelper.ts
@@ -129,7 +129,6 @@ export const useFilesHelper = ({
   getRoomList,
   getIcon,
   t,
-  selectedFolders,
   setIsSelectedParentFolder,
 }: useFilesHelpersProps) => {
   const getFileList = React.useCallback(
@@ -265,7 +264,7 @@ export const useFilesHelper = ({
               //   folderInfo;
 
               if (!foundParentId) {
-                currentFolderIndex = selectedFolders.findIndex((x) => x === id);
+                currentFolderIndex = disabledItems.findIndex((x) => x === id);
               }
 
               if (!foundParentId && currentFolderIndex !== -1) {

--- a/packages/client/src/components/FilesSelector/index.tsx
+++ b/packages/client/src/components/FilesSelector/index.tsx
@@ -310,10 +310,8 @@ const FilesSelector = ({
 
           if (index !== maxLength && currentFolderIndex !== -1) {
             foundParentId = true;
+            !isSelectedParentFolder && setIsSelectedParentFolder(true);
           }
-
-          if (foundParentId && !isSelectedParentFolder)
-            setIsSelectedParentFolder(true);
 
           if (index === maxLength && !foundParentId && isSelectedParentFolder)
             setIsSelectedParentFolder(false);

--- a/packages/client/src/components/FilesSelector/index.tsx
+++ b/packages/client/src/components/FilesSelector/index.tsx
@@ -495,6 +495,7 @@ const FilesSelector = ({
 
   const isDisabled = getIsDisabled(
     isFirstLoad,
+    isSelectedParentFolder,
     fromFolderId == selectedItemId,
     selectedItemType === "rooms",
     isRoot,
@@ -506,8 +507,7 @@ const FilesSelector = ({
     filterParam,
     !!selectedFileInfo,
     includeFolder,
-    isRestore,
-    isSelectedParentFolder
+    isRestore
   );
 
   const SelectorBody = (

--- a/packages/client/src/components/FilesSelector/index.tsx
+++ b/packages/client/src/components/FilesSelector/index.tsx
@@ -102,7 +102,6 @@ const FilesSelector = ({
   withHeader,
   getIcon,
   isRoomBackup,
-  selectedFolders,
 }: FilesSelectorProps) => {
   const { t } = useTranslation(["Files", "Common", "Translations"]);
 
@@ -206,7 +205,6 @@ const FilesSelector = ({
     getRoomList,
     getIcon,
     t,
-    selectedFolders,
   });
 
   const onSelectAction = (item: Item) => {
@@ -303,7 +301,7 @@ const FilesSelector = ({
           currentFolderIndex = -1;
         const newBreadCrumbs = breadCrumbs.map((item, index) => {
           if (!foundParentId) {
-            currentFolderIndex = selectedFolders.findIndex(
+            currentFolderIndex = disabledItems.findIndex(
               (id) => id === item?.id
             );
           }
@@ -704,17 +702,10 @@ export default inject(
       }
     });
 
-    const selectedFolders =
-      selections.length === 1 &&
-      (selections[0].isFolder || selections[0].parentId)
-        ? [selections[0].id]
-        : disabledItems;
-
     const includeFolder =
       selectionsWithoutEditing.filter((i: any) => i.isFolder).length > 0;
 
     return {
-      selectedFolders,
       currentFolderId,
       fromFolderId,
       parentId,

--- a/packages/client/src/components/FilesSelector/index.tsx
+++ b/packages/client/src/components/FilesSelector/index.tsx
@@ -102,7 +102,7 @@ const FilesSelector = ({
   withHeader,
   getIcon,
   isRoomBackup,
-  selectionId,
+  selectedFolders,
 }: FilesSelectorProps) => {
   const { t } = useTranslation(["Files", "Common", "Translations"]);
 
@@ -206,7 +206,7 @@ const FilesSelector = ({
     getRoomList,
     getIcon,
     t,
-    selectionId,
+    selectedFolders,
   });
 
   const onSelectAction = (item: Item) => {
@@ -299,9 +299,16 @@ const FilesSelector = ({
         );
 
         const maxLength = breadCrumbs.length - 1;
-        let foundParentId = false;
+        let foundParentId = false,
+          currentFolderIndex = -1;
         const newBreadCrumbs = breadCrumbs.map((item, index) => {
-          if (index !== maxLength && selectionId === item.id) {
+          if (!foundParentId) {
+            currentFolderIndex = selectedFolders.findIndex(
+              (id) => id === item?.id
+            );
+          }
+
+          if (index !== maxLength && currentFolderIndex !== -1) {
             foundParentId = true;
           }
 
@@ -699,13 +706,17 @@ export default inject(
       }
     });
 
-    const selectionId = selections.length === 1 ? selections[0].id : null;
+    const selectedFolders =
+      selections.length === 1 &&
+      (selections[0].isFolder || selections[0].parentId)
+        ? [selections[0].id]
+        : disabledItems;
 
     const includeFolder =
       selectionsWithoutEditing.filter((i: any) => i.isFolder).length > 0;
 
     return {
-      selectionId,
+      selectedFolders,
       currentFolderId,
       fromFolderId,
       parentId,

--- a/packages/client/src/components/FilesSelector/utils.ts
+++ b/packages/client/src/components/FilesSelector/utils.ts
@@ -71,7 +71,8 @@ export const getIsDisabled = (
   filterParam?: string,
   isFileSelected?: boolean,
   includeFolder?: boolean,
-  isRestore?: boolean
+  isRestore?: boolean,
+  isSelectedParentFolder
 ) => {
   if (isFirstLoad) return true;
   if (isRequestRunning) return true;
@@ -80,6 +81,7 @@ export const getIsDisabled = (
   if (sameId && isCopy && includeFolder) return true;
   if (isRooms) return true;
   if (isRoot) return true;
+  if (isSelectedParentFolder) return true;
   if (isCopy) return !security?.CopyTo;
   if (isMove || isRestoreAll || isRestore) return !security?.MoveTo;
 

--- a/packages/client/src/components/FilesSelector/utils.ts
+++ b/packages/client/src/components/FilesSelector/utils.ts
@@ -60,6 +60,7 @@ export const getAcceptButtonLabel = (
 
 export const getIsDisabled = (
   isFirstLoad: boolean,
+  isSelectedParentFolder: boolean,
   sameId?: boolean,
   isRooms?: boolean,
   isRoot?: boolean,
@@ -71,8 +72,7 @@ export const getIsDisabled = (
   filterParam?: string,
   isFileSelected?: boolean,
   includeFolder?: boolean,
-  isRestore?: boolean,
-  isSelectedParentFolder
+  isRestore?: boolean
 ) => {
   if (isFirstLoad) return true;
   if (isRequestRunning) return true;


### PR DESCRIPTION
The ability to select your own directory, as well as child subfolders for copying/moving a folder, was removed.