### PR TITLE
Bugfix/save table sorting

### DIFF
--- a/packages/client/src/components/Article/Body/index.js
+++ b/packages/client/src/components/Article/Body/index.js
@@ -105,6 +105,17 @@ const ArticleBodyContent = (props) => {
         case myFolderId:
           const myFilter = FilesFilter.getDefault();
           myFilter.folder = folderId;
+
+          const filterStorageItem =
+            userId && localStorage.getItem(`UserFilter=${userId}`);
+
+          if (filterStorageItem) {
+            const splitFilter = filterStorageItem.split(",");
+
+            myFilter.sortBy = splitFilter[0];
+            myFilter.sortOrder = splitFilter[1];
+          }
+
           params = myFilter.toUrlParams();
 
           path = getCategoryUrl(CategoryType.Personal);
@@ -123,6 +134,17 @@ const ArticleBodyContent = (props) => {
         case recycleBinFolderId:
           const recycleBinFilter = FilesFilter.getDefault();
           recycleBinFilter.folder = folderId;
+
+          const filterStorageTrash =
+            userId && localStorage.getItem(`UserFilterTrash=${userId}`);
+
+          if (filterStorageTrash) {
+            const splitFilterTrash = filterStorageTrash.split(",");
+
+            recycleBinFilter.sortBy = splitFilterTrash[0];
+            recycleBinFilter.sortOrder = splitFilterTrash[1];
+          }
+
           params = recycleBinFilter.toUrlParams();
           path = getCategoryUrl(CategoryType.Trash);
 

--- a/packages/client/src/pages/Home/Section/Tabs/MyDocumentsTabs/index.js
+++ b/packages/client/src/pages/Home/Section/Tabs/MyDocumentsTabs/index.js
@@ -38,6 +38,7 @@ const MyDocumentsTabs = ({
   setFilter,
   showBodyLoader,
   isRoot,
+  user,
 }) => {
   const { t } = useTranslation(["Common", "Files"]);
 
@@ -56,13 +57,25 @@ const MyDocumentsTabs = ({
     const filter = FilesFilter.getDefault();
     const url = window.DocSpace.location.pathname;
 
-    if (e.id === "recent") {
+    const recent = e.id === "recent";
+
+    const filterStorageItem = user?.id
+      ? recent
+        ? localStorage.getItem(`UserFilterRecent=${user.id}`)
+        : localStorage.getItem(`UserFilter=${user.id}`)
+      : null;
+
+    if (filterStorageItem) {
+      const splitFilter = filterStorageItem.split(",");
+
+      filter.sortBy = splitFilter[0];
+      filter.sortOrder = splitFilter[1];
+    } else if (recent) filter.sortBy = "LastOpened";
+
+    if (recent) {
       filter.folder = e.id;
       filter.searchArea = 3;
-      filter.sortBy = "LastOpened";
-    } else {
-      filter.searchArea = null;
-    }
+    } else filter.searchArea = null;
 
     setFilter(filter);
     window.DocSpace.navigate(`${url}?${filter.toUrlParams()}`);
@@ -83,17 +96,18 @@ const MyDocumentsTabs = ({
 };
 
 export default inject(
-  ({ treeFoldersStore, filesStore, clientLoadingStore }) => {
+  ({ treeFoldersStore, filesStore, clientLoadingStore, userStore }) => {
     const { isPersonalRoom, isRecentTab, isRoot } = treeFoldersStore;
     const { setFilter } = filesStore;
     const { showBodyLoader } = clientLoadingStore;
-
+    const { user } = userStore;
     return {
       isPersonalRoom,
       isRecentTab,
       setFilter,
       showBodyLoader,
       isRoot,
+      user,
     };
   },
 )(observer(MyDocumentsTabs));

--- a/packages/client/src/store/ContextOptionsStore.js
+++ b/packages/client/src/store/ContextOptionsStore.js
@@ -1942,7 +1942,7 @@ class ContextOptionsStore {
       selection.findIndex((k) => k.security.Download) !== -1;
 
     const favoriteItems = selection.filter((k) =>
-      k.contextOptions.includes("mark-as-favorite"),
+      k.contextOptions?.includes("mark-as-favorite"),
     );
 
     const moveItems = selection.filter((k) =>

--- a/packages/client/src/store/FilesActionsStore.js
+++ b/packages/client/src/store/FilesActionsStore.js
@@ -1459,6 +1459,23 @@ class FilesActionStore {
 
     filter.folder = id;
 
+    if (isRoom) {
+      const key =
+        categoryType === CategoryType.Archive
+          ? `UserFilterArchiveRoom=${this.userStore.user?.id}`
+          : `UserFilterSharedRoom=${this.userStore.user?.id}`;
+
+      const filterStorageSharedRoom =
+        this.userStore.user?.id && localStorage.getItem(key);
+
+      if (filterStorageSharedRoom) {
+        const splitFilter = filterStorageSharedRoom.split(",");
+
+        filter.sortBy = splitFilter[0];
+        filter.sortOrder = splitFilter[1];
+      }
+    }
+
     const url = getCategoryUrl(categoryType, id);
 
     window.DocSpace.navigate(`${url}?${filter.toUrlParams()}`, { state });
@@ -2334,7 +2351,8 @@ class FilesActionStore {
   onMarkAsRead = (item) => this.markAsRead([], [`${item.id}`], item);
 
   openFileAction = (item, t, e) => {
-    const { openDocEditor, isPrivacyFolder, setSelection } = this.filesStore;
+    const { openDocEditor, isPrivacyFolder, setSelection, categoryType } =
+      this.filesStore;
     const { currentDeviceType } = this.settingsStore;
     const { fileItemsList } = this.pluginStore;
     const { enablePlugins } = this.settingsStore;
@@ -2384,6 +2402,30 @@ class FilesActionStore {
       );
 
       const filter = FilesFilter.getDefault();
+
+      const filterObj = FilesFilter.getFilter(window.location);
+
+      if (isRoom) {
+        const key =
+          categoryType === CategoryType.Archive
+            ? `UserFilterArchiveRoom=${this.userStore.user?.id}`
+            : `UserFilterSharedRoom=${this.userStore.user?.id}`;
+
+        const filterStorageSharedRoom =
+          this.userStore.user?.id && localStorage.getItem(key);
+
+        if (filterStorageSharedRoom) {
+          const splitFilter = filterStorageSharedRoom.split(",");
+
+          filter.sortBy = splitFilter[0];
+          filter.sortOrder = splitFilter[1];
+        }
+      } else {
+        // For the document section at all levels there is one sorting
+        filter.sortBy = filterObj.sortBy;
+        filter.sortOrder = filterObj.sortOrder;
+      }
+
       filter.folder = id;
 
       const url = `${path}?${filter.toUrlParams()}`;
@@ -2604,6 +2646,11 @@ class FilesActionStore {
     const { navigationPath, rootFolderType } = this.selectedFolderStore;
 
     const filter = FilesFilter.getDefault();
+
+    const filterObj = FilesFilter.getFilter(window.location);
+
+    filter.sortBy = filterObj.sortBy;
+    filter.sortOrder = filterObj.sortOrder;
 
     filter.folder = id;
 

--- a/packages/client/src/store/FilesStore.js
+++ b/packages/client/src/store/FilesStore.js
@@ -1492,7 +1492,7 @@ class FilesStore {
       const splitFilter = filterStorageItem.split(",");
 
       filterData.sortBy = splitFilter[0];
-      filterData.sortOrder = splitFilter[2];
+      filterData.sortOrder = splitFilter[1];
     }
 
     if (!this.settingsStore.withPaging) {

--- a/packages/shared/api/rooms/filter.js
+++ b/packages/shared/api/rooms/filter.js
@@ -64,10 +64,10 @@ const DEFAULT_SEARCH_AREA = RoomSearchArea.Active;
 const TAGS = "tags";
 const DEFAULT_TAGS = null;
 
-const SORT_BY = "sortby";
+const SORT_BY = "sortBy";
 const DEFAULT_SORT_BY = "DateAndTime";
 
-const SORT_ORDER = "sortorder";
+const SORT_ORDER = "sortOrder";
 const DEFAULT_SORT_ORDER = "descending";
 
 const EXCLUDE_SUBJECT = "excludeSubject";
@@ -84,6 +84,21 @@ const DEFAULT_QUOTA_FILTER = null;
 
 const STORAGE_FILTER = "storageFilter";
 const DEFAULT_STORAGE_FILTER = null;
+
+export const toJSON = (filter) => {
+  const filterObject = transform(
+    filter,
+    (result, value, key) => {
+      if (value instanceof Function) return result;
+      if (value === null || value === false) return result;
+
+      result[key] = value;
+    },
+    {},
+  );
+
+  return JSON.stringify(filterObject);
+};
 
 class RoomsFilter {
   static getDefault(userId, searchArea) {
@@ -264,19 +279,6 @@ class RoomsFilter {
     return this.page > 0;
   };
 
-  toJSON = (filter) => {
-    const filterObject = transform(
-      filter,
-      (result, value, key) => {
-        if (value instanceof Function) return result;
-        if (value === null || value === false) return result;
-        result[key] = value;
-      },
-      {},
-    );
-    return JSON.stringify(filterObject);
-  };
-
   toApiUrlParams = () => {
     const {
       page,
@@ -422,7 +424,7 @@ class RoomsFilter {
     if (!sharedStorageFilter && userId) {
       localStorage.setItem(
         `UserRoomsSharedFilter=${userId}`,
-        this.toJSON(defaultFilter),
+        toJSON(defaultFilter),
       );
     }
 
@@ -430,11 +432,11 @@ class RoomsFilter {
       defaultFilter.searchArea = RoomSearchArea.Archive;
       localStorage.setItem(
         `UserRoomsArchivedFilter=${userId}`,
-        this.toJSON(defaultFilter),
+        toJSON(defaultFilter),
       );
     }
 
-    const filterJSON = this.toJSON(dtoFilter);
+    const filterJSON = toJSON(dtoFilter);
 
     const currentStorageFilter =
       dtoFilter.searchArea === RoomSearchArea.Active


### PR DESCRIPTION
- Added saving of your own sorting for each section and each tab
- Added its own sorting inside the room, which differs from the sorting in the rooms section, as there are different tables
- Sorting within rooms is preserved, it is the same for all rooms, also in the Documents section, when moving by level, sorting is preserved
- Corrected the SORT_BY and SORT_ORDER values ​​for rooms to be correct, matching the URL